### PR TITLE
docs: Fix a few typos

### DIFF
--- a/everything_else/djfrontend/django-1.0.2/contrib/admin/media/js/admin/ordering.js
+++ b/everything_else/djfrontend/django-1.0.2/contrib/admin/media/js/admin/ordering.js
@@ -109,7 +109,7 @@ function getOrder() {
 }
 
 function setOrder(id_list) {
-    /* Set the current order to match the lsit of IDs */
+    /* Set the current order to match the list of IDs */
     var temp_lis = new Array();
     for (var i = 0; i < id_list.length; i++) {
         var id = 'p' + id_list[i];

--- a/everything_else/djfrontend/django-1.0.2/contrib/admin/media/js/getElementsBySelector.js
+++ b/everything_else/djfrontend/django-1.0.2/contrib/admin/media/js/getElementsBySelector.js
@@ -112,7 +112,7 @@ document.getElementsBySelector = function(selector) {
         case '=': // Equality
           checkFunction = function(e) { return (e.getAttribute(attrName) == attrValue); };
           break;
-        case '~': // Match one of space seperated words 
+        case '~': // Match one of space separated words 
           checkFunction = function(e) { return (e.getAttribute(attrName).match(new RegExp('\\b'+attrValue+'\\b'))); };
           break;
         case '|': // Match start with value followed by optional hyphen

--- a/everything_else/djfrontend/django-1.0.2/contrib/gis/models.py
+++ b/everything_else/djfrontend/django-1.0.2/contrib/gis/models.py
@@ -13,7 +13,7 @@ if HAS_GDAL:
 class SpatialRefSysMixin(object):
     """
     The SpatialRefSysMixin is a class used by the database-dependent
-    SpatialRefSys objects to reduce redundnant code.
+    SpatialRefSys objects to reduce redundant code.
     """
 
     # For pulling out the spheroid from the spatial reference string. This

--- a/everything_else/djfrontend/django-1.0.2/core/files/storage.py
+++ b/everything_else/djfrontend/django-1.0.2/core/files/storage.py
@@ -91,7 +91,7 @@ class Storage(object):
 
     def exists(self, name):
         """
-        Returns True if a file referened by the given name already exists in the
+        Returns True if a file referenced by the given name already exists in the
         storage system, or False if the name is available for a new file.
         """
         raise NotImplementedError()

--- a/everything_else/djfrontend/django-1.0.2/http/__init__.py
+++ b/everything_else/djfrontend/django-1.0.2/http/__init__.py
@@ -108,7 +108,7 @@ class HttpRequest(object):
 
     def _get_upload_handlers(self):
         if not self._upload_handlers:
-            # If thre are no upload handlers defined, initialize them from settings.
+            # If there are no upload handlers defined, initialize them from settings.
             self._initialize_handlers()
         return self._upload_handlers
 

--- a/everything_else/djfrontend/django-1.0.2/template/defaulttags.py
+++ b/everything_else/djfrontend/django-1.0.2/template/defaulttags.py
@@ -463,7 +463,7 @@ def cycle(parser, token):
         {% endfor %}
 
     Outside of a loop, give the values a unique name the first time you call
-    it, then use that name each sucessive time through::
+    it, then use that name each successive time through::
 
             <tr class="{% cycle 'row1' 'row2' 'row3' as rowcolors %}">...</tr>
             <tr class="{% cycle rowcolors %}">...</tr>

--- a/everything_else/djfrontend/django-1.0.2/utils/_decimal.py
+++ b/everything_else/djfrontend/django-1.0.2/utils/_decimal.py
@@ -2249,7 +2249,7 @@ class Context(object):
 
         If the flag is in _ignored_flags, returns the default response.
         Otherwise, it increments the flag, then, if the corresponding
-        trap_enabler is set, it reaises the exception.  Otherwise, it returns
+        trap_enabler is set, it raises the exception.  Otherwise, it returns
         the default value after incrementing the flag.
         """
         error = _condition_map.get(condition, condition)


### PR DESCRIPTION
There are small typos in:
- everything_else/djfrontend/django-1.0.2/contrib/admin/media/js/admin/ordering.js
- everything_else/djfrontend/django-1.0.2/contrib/admin/media/js/getElementsBySelector.js
- everything_else/djfrontend/django-1.0.2/contrib/gis/models.py
- everything_else/djfrontend/django-1.0.2/core/files/storage.py
- everything_else/djfrontend/django-1.0.2/http/__init__.py
- everything_else/djfrontend/django-1.0.2/template/defaulttags.py
- everything_else/djfrontend/django-1.0.2/utils/_decimal.py

Fixes:
- Should read `there` rather than `thre`.
- Should read `successive` rather than `sucessive`.
- Should read `separated` rather than `seperated`.
- Should read `referenced` rather than `referened`.
- Should read `redundant` rather than `redundnant`.
- Should read `raises` rather than `reaises`.
- Should read `list` rather than `lsit`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md